### PR TITLE
Pass HTTP Request Headers to PHP via FastCGI

### DIFF
--- a/src/http/proxy_server.rs
+++ b/src/http/proxy_server.rs
@@ -109,15 +109,13 @@ async fn handle(
         .set_server_software("rymfony/rust/fastcgi-client")
         .set_server_protocol(http_version);
 
-    for header in headers.iter() {
-        let (name, value) = header;
+    let mut headers_normalized = Vec::new();
+    for (name, value) in headers.iter() {
+        let header_name = format!("HTTP_{}", name.as_str().replace("-", "_").to_uppercase());
 
-        let header_name = format!("HTTP_{}", name.as_str().replace("-", "_").to_uppercase()).to_string();
-        let header_name = header_name.as_str();
-
-        // TODO: FIND A WAY TO MAKE THIS NEXT LINE WORK
-        params.insert(header_name, value.to_str().unwrap());
+        headers_normalized.push((header_name, value.to_str().unwrap()));
     };
+    params.extend(headers_normalized.iter().map(|(k, s)| (k.as_str(), *s)));
 
     let output = client.do_request(&params, &mut std::io::Cursor::new(body)).unwrap();
 

--- a/src/http/proxy_server.rs
+++ b/src/http/proxy_server.rs
@@ -109,6 +109,16 @@ async fn handle(
         .set_server_software("rymfony/rust/fastcgi-client")
         .set_server_protocol(http_version);
 
+    for header in headers.iter() {
+        let (name, value) = header;
+
+        let header_name = format!("HTTP_{}", name.as_str().replace("-", "_").to_uppercase()).to_string();
+        let header_name = header_name.as_str();
+
+        // TODO: FIND A WAY TO MAKE THIS NEXT LINE WORK
+        params.insert(header_name, value.to_str().unwrap());
+    };
+
     let output = client.do_request(&params, &mut std::io::Cursor::new(body)).unwrap();
 
     let stdout = output.get_stdout();


### PR DESCRIPTION
For now, the latest logs say this:

```
$ cargo build
   Compiling rymfony v0.1.0 (/var/www/rymfony)
error[E0597]: `header_name` does not live long enough
   --> src\http\proxy_server.rs:116:27
    |
116 |         let header_name = header_name.as_str();
    |                           ^^^^^^^^^^^ borrowed value does not live long enough
...
120 |     };
    |     - `header_name` dropped here while still borrowed
121 |
122 |     let output = client.do_request(&params, &mut std::io::Cursor::new(body)).unwrap();
    |                                    ------- borrow later used here

error: aborting due to previous error

For more information about this error, try `rustc --explain E0597`.
```