### PR TITLE
fix merge_binaries and added default path for mac os

### DIFF
--- a/src/php/binaries.rs
+++ b/src/php/binaries.rs
@@ -31,12 +31,9 @@ pub(crate) fn all() -> HashMap<PhpVersion, PhpBinary> {
 
     merge_binaries(binaries_from_dir(PathBuf::from("/usr/bin")), &mut binaries);
     merge_binaries(binaries_from_dir(PathBuf::from("/usr/sbin")), &mut binaries);
-
-    if cfg!(target_os = "macos") {
-        merge_binaries(binaries_from_dir(PathBuf::from("/usr/local/Cellar/php/*/bin")), &mut binaries);
-        merge_binaries(binaries_from_dir(PathBuf::from("/usr/local/Cellar/php@*/*/bin")), &mut binaries);
-        merge_binaries(binaries_from_dir(PathBuf::from("/usr/local/php*/bin")), &mut binaries);
-    }
+    merge_binaries(binaries_from_dir(PathBuf::from("/usr/local/Cellar/php/*/bin")), &mut binaries);
+    merge_binaries(binaries_from_dir(PathBuf::from("/usr/local/Cellar/php@*/*/bin")), &mut binaries);
+    merge_binaries(binaries_from_dir(PathBuf::from("/usr/local/php*/bin")), &mut binaries);
 
     binaries
 }

--- a/src/php/binaries.rs
+++ b/src/php/binaries.rs
@@ -158,6 +158,6 @@ fn merge_binaries(
             into.get_mut(&version).unwrap().merge_with(binary);
         } else {
             into.insert(version, binary);
-        };
+        }
     }
 }


### PR DESCRIPTION
- Adding/Fixing Mac OS default directories
- Re-using `merge_binaries` in `binaries_from_env` 
- Above showed a bug in `merge_binaries` which was fixed

Review with care - missing rust know-how here!

Now the output is:

```bash
$ target/release/rymfony php:list 
┌─────────┬───────────────────────────────────────────────┬──────────────────────────────────────────┬─────────┐
| Version | PHP CLI                                       | PHP FPM                                  | PHP CGI |
├─────────┼───────────────────────────────────────────────┼──────────────────────────────────────────┼─────────┤
| 7.4.9   | /usr/local/Cellar/php/7.4.9/bin/php           | /usr/local/Cellar/php/7.4.9/sbin/php-fpm |         |
| 5.5.5   | /usr/local/php5-5.5.5-20131020-222726/bin/php |                                          |         |
| 7.3.11  | /usr/bin/php                                  | /usr/sbin/php-fpm                        |         |
| 7.3.21  | /usr/local/Cellar/php@7.3/7.3.21/bin/php      |                                          |         |
└─────────┴───────────────────────────────────────────────┴──────────────────────────────────────────┴─────────┘
```
Compared to :
```
$ symfony local:php:list
┌─────────┬───────────────────────────────────────┬─────────┬───────────────────────────────┬──────────────────────────────┬─────────┬─────────┐
│ Version │               Directory               │ PHP CLI │            PHP FPM            │           PHP CGI            │ Server  │ System? │
├─────────┼───────────────────────────────────────┼─────────┼───────────────────────────────┼──────────────────────────────┼─────────┼─────────┤
│ 5.5.5   │ /usr/local/php5-5.5.5-20131020-222726 │ bin/php │ sbin/php-fpm                  │ bin/php-cgi                  │ PHP FPM │         │
│ 7.3.11  │ /usr                                  │ bin/php │ sbin/php-fpm                  │                              │ PHP FPM │         │
│ 7.3.21  │ /usr/local/Cellar/php@7.3/7.3.21      │ bin/php │ sbin/php-fpm                  │ bin/php-cgi                  │ PHP FPM │         │
│ 7.4.9   │ /usr/local                            │ bin/php │ Cellar/php/7.4.9/sbin/php-fpm │ Cellar/php/7.4.9/bin/php-cgi │ PHP FPM │ *       │
└─────────┴───────────────────────────────────────┴─────────┴───────────────────────────────┴──────────────────────────────┴─────────┴─────────┘
```
