### PR TITLE
Detect cgi on Linux as well

### DIFF
--- a/src/php/binaries.rs
+++ b/src/php/binaries.rs
@@ -69,7 +69,7 @@ fn binaries_from_dir(path: PathBuf) -> HashMap<PhpVersion, PhpBinary> {
     } else {
         // This will probably need to be updated for other platforms.
         // This matches "php", "php7.4", "php-fpm", "php7.4-fpm" and "php-fpm7.4"
-        Regex::new(r"php(\d+(\.\d+))?([_-]?fpm)?(\d+(\.\d+))?$").unwrap()
+        Regex::new(r"php(\d+(\.\d+))?([_-]?fpm|[_-]?cgi)?(\d+(\.\d+))?$").unwrap()
     };
 
     let mut binaries_paths: Vec<String> = Vec::new();


### PR DESCRIPTION
Not sure if that was intentionally, but having an empty column in the list command is weird, when the cgi executables are actually existing.

Before:
```bash
┌─────────┬───────────────────────────────────────────────┬──────────────────────────────────────────┬─────────┐
| Version | PHP CLI                                       | PHP FPM                                  | PHP CGI |
├─────────┼───────────────────────────────────────────────┼──────────────────────────────────────────┼─────────┤
| 7.4.9   | /usr/local/Cellar/php/7.4.9/bin/php           | /usr/local/Cellar/php/7.4.9/sbin/php-fpm |         |
| 5.5.5   | /usr/local/php5-5.5.5-20131020-222726/bin/php |                                          |         |
| 7.3.11  | /usr/bin/php                                  | /usr/sbin/php-fpm                        |         |
| 7.3.21  | /usr/local/Cellar/php@7.3/7.3.21/bin/php      |                                          |         |
└─────────┴───────────────────────────────────────────────┴──────────────────────────────────────────┴─────────┘
```
Afterwards:
```bash
┌─────────┬───────────────────────────────────────────────┬──────────────────────────────────────────┬───────────────────────────────────────────────────┐
| Version | PHP CLI                                       | PHP FPM                                  | PHP CGI                                           |
├─────────┼───────────────────────────────────────────────┼──────────────────────────────────────────┼───────────────────────────────────────────────────┤
| 7.4.9   | /usr/local/Cellar/php/7.4.9/bin/php           | /usr/local/Cellar/php/7.4.9/sbin/php-fpm | /usr/local/Cellar/php/7.4.9/bin/php-cgi           |
| 7.3.11  | /usr/bin/php                                  | /usr/sbin/php-fpm                        |                                                   |
| 7.3.21  | /usr/local/Cellar/php@7.3/7.3.21/bin/php      |                                          | /usr/local/Cellar/php@7.3/7.3.21/bin/php-cgi      |
| 5.5.5   | /usr/local/php5-5.5.5-20131020-222726/bin/php |                                          | /usr/local/php5-5.5.5-20131020-222726/bin/php-cgi |
└─────────┴───────────────────────────────────────────────┴──────────────────────────────────────────┴───────────────────────────────────────────────────┘
```
Output partially based on #17