### PR TITLE
Order list command by version

### DIFF
--- a/src/commands/php_list.rs
+++ b/src/commands/php_list.rs
@@ -37,7 +37,10 @@ pub(crate) fn php_list() {
     table.set_format(format);
     table.set_titles(row!["Version", "PHP CLI", "PHP FPM", "PHP CGI"]);
 
-    for (php_version, php_binary) in binaries {
+    let mut ordered_binaries: Vec<_> = binaries.into_iter().collect();
+    ordered.sort_by(|x,y| x.0.version().cmp(y.0.version()));
+
+    for (php_version, php_binary) in ordered_binaries {
         table.add_row(row![
             php_version.version(),
             php_binary.cli(),

--- a/src/commands/php_list.rs
+++ b/src/commands/php_list.rs
@@ -38,7 +38,7 @@ pub(crate) fn php_list() {
     table.set_titles(row!["Version", "PHP CLI", "PHP FPM", "PHP CGI"]);
 
     let mut ordered_binaries: Vec<_> = binaries.into_iter().collect();
-    ordered.sort_by(|x,y| x.0.version().cmp(y.0.version()));
+    ordered_binaries.sort_by(|x,y| x.0.version().cmp(y.0.version()));
 
     for (php_version, php_binary) in ordered_binaries {
         table.add_row(row![


### PR DESCRIPTION
Previously the output of the list command was somewhat unordered.
Not only that, but executing it multiple times in a row resulted in different outputs:
```
$ target/release/rymfony php:list
┌─────────┬───────────────────────────────────────────────┬──────────────────────────────────────────┬─────────┐
| Version | PHP CLI                                       | PHP FPM                                  | PHP CGI |
├─────────┼───────────────────────────────────────────────┼──────────────────────────────────────────┼─────────┤
| 7.3.11  | /usr/bin/php                                  | /usr/sbin/php-fpm                        |         |
| 7.4.9   | /usr/local/Cellar/php/7.4.9/bin/php           | /usr/local/Cellar/php/7.4.9/sbin/php-fpm |         |
| 7.3.21  | /usr/local/Cellar/php@7.3/7.3.21/bin/php      |                                          |         |
| 5.5.5   | /usr/local/php5-5.5.5-20131020-222726/bin/php |                                          |         |
└─────────┴───────────────────────────────────────────────┴──────────────────────────────────────────┴─────────┘

$ target/release/rymfony php:list
┌─────────┬───────────────────────────────────────────────┬──────────────────────────────────────────┬─────────┐
| Version | PHP CLI                                       | PHP FPM                                  | PHP CGI |
├─────────┼───────────────────────────────────────────────┼──────────────────────────────────────────┼─────────┤
| 7.4.9   | /usr/local/Cellar/php/7.4.9/bin/php           | /usr/local/Cellar/php/7.4.9/sbin/php-fpm |         |
| 5.5.5   | /usr/local/php5-5.5.5-20131020-222726/bin/php |                                          |         |
| 7.3.11  | /usr/bin/php                                  | /usr/sbin/php-fpm                        |         |
| 7.3.21  | /usr/local/Cellar/php@7.3/7.3.21/bin/php      |                                          |         |
└─────────┴───────────────────────────────────────────────┴──────────────────────────────────────────┴─────────┘
```

This PR fixes the order (now similar to Symfony - from lowest to highest):
```bash
┌─────────┬───────────────────────────────────────────────┬──────────────────────────────────────────┬───────────────────────────────────────────────────┐
| Version | PHP CLI                                       | PHP FPM                                  | PHP CGI                                           |
├─────────┼───────────────────────────────────────────────┼──────────────────────────────────────────┼───────────────────────────────────────────────────┤
| 5.5.5   | /usr/local/php5-5.5.5-20131020-222726/bin/php |                                          | /usr/local/php5-5.5.5-20131020-222726/bin/php-cgi |
| 7.3.11  | /usr/bin/php                                  | /usr/sbin/php-fpm                        |                                                   |
| 7.3.21  | /usr/local/Cellar/php@7.3/7.3.21/bin/php      |                                          | /usr/local/Cellar/php@7.3/7.3.21/bin/php-cgi      |
| 7.4.9   | /usr/local/Cellar/php/7.4.9/bin/php           | /usr/local/Cellar/php/7.4.9/sbin/php-fpm | /usr/local/Cellar/php/7.4.9/bin/php-cgi           |
└─────────┴───────────────────────────────────────────────┴──────────────────────────────────────────┴───────────────────────────────────────────────────┘
```
Output partially based on #17 and #18 