### PR TITLE
detect system php and preferred SAPI

### DIFF
--- a/src/commands/php_list.rs
+++ b/src/commands/php_list.rs
@@ -35,17 +35,19 @@ pub(crate) fn php_list() {
         .build();
 
     table.set_format(format);
-    table.set_titles(row!["Version", "PHP CLI", "PHP FPM", "PHP CGI"]);
+    table.set_titles(row!["Version", "PHP CLI", "PHP FPM", "PHP CGI", "System"]);
 
     let mut ordered_binaries: Vec<_> = binaries.into_iter().collect();
     ordered_binaries.sort_by(|x,y| x.0.version().cmp(y.0.version()));
 
     for (php_version, php_binary) in ordered_binaries {
+        let system = if php_binary.system() { "*" } else { "" };
         table.add_row(row![
             php_version.version(),
             php_binary.cli(),
             php_binary.fpm(),
             php_binary.cgi(),
+            system
         ]);
     }
 

--- a/src/php/binaries.rs
+++ b/src/php/binaries.rs
@@ -18,7 +18,9 @@ pub(crate) fn current() -> String {
 
     for (_version, _binary) in _binaries {
         // TODO: check for a better solution to choose current PHP version
-        //return binary.path().to_string();
+        if _binary.system() {
+            return _binary.preferred_sapi().to_string();
+        }
     }
 
     "php".to_string()
@@ -153,7 +155,11 @@ fn merge_binaries(
     from: HashMap<PhpVersion, PhpBinary>,
     into: &mut HashMap<PhpVersion, PhpBinary>
 ) {
-    for (version, binary) in from {
+    for (version, mut binary) in from {
+        // this needs to be fixed, but for now we assume that the first ever found version is
+        // the one that is first in PATH and therefor the "system" binary
+        &binary.set_system(if into.len() == 0 { true } else { false });
+
         if into.contains_key(&version) {
             into.get_mut(&version).unwrap().merge_with(binary);
         } else {

--- a/src/php/structs.rs
+++ b/src/php/structs.rs
@@ -158,6 +158,26 @@ impl PhpBinary {
         }
     }
 
+    pub(crate) fn system(&self) -> bool {
+        self.system.clone()
+    }
+
+    pub(crate) fn set_system(&mut self, is_system: bool) {
+        self.system = is_system;
+    }
+
+    pub(crate) fn preferred_sapi(&self) -> String {
+        if self.fpm != "" {
+            return self.fpm.clone();
+        } else if self.cgi != "" {
+            return self.cgi.clone();
+        } else if self.cli != "" {
+            return self.cli.clone();
+        } else {
+            panic!("Cannot detect preferred sapi for PHP \"{}\"", self._version.version());
+        }
+    }
+
     pub(crate) fn add_sapi(&mut self, sapi: &PhpServerSapi, path: &String) {
         match sapi {
             PhpServerSapi::FPM => {


### PR DESCRIPTION
Ok, this is just another "I don't know what the heck I am doing, but `Hey! It works ..." PR 😁 just kidding, but:

<img width="1355" alt="Bildschirmfoto 2020-08-27 um 20 08 08" src="https://user-images.githubusercontent.com/533162/91478946-0a652180-e8a1-11ea-8f03-1aa2c717cea5.png">

- Added logic to detect system php: for now the first found binary in the PATH is used for that - I guess thats how a shell finds an executable as well: by looking through the path and using the first one that is available
- Added a column to mark/display the "system binary" in the list command
- Added a method to detect preferred SAPI and use it in server:start (order: fpm, cgi, cli, panic)

With this change I am finally able to see a working page!
Bonus points for: I could even open my Symfony project with it. Rather slow by now (probably becuase of the response buffering vs streaming issue?) ... but hey: not it works for me 🎉 
