### PR TITLE
deactivate systemd if unsupported

### DIFF
--- a/src/php/server_fpm.rs
+++ b/src/php/server_fpm.rs
@@ -29,7 +29,7 @@ error_log = /dev/fd/2
 ; This gives the advantage of keeping control over the process,
 ; and possibly retrieve logs too (since logs can be piped with fpm's stderr with current config)
 daemonize = no
-systemd_interval = 0
+{{ systemd }}systemd_interval = 0
 
 [www]
 ; Only works if launched as a root user
@@ -79,11 +79,15 @@ pub(crate) fn start(php_bin: String) -> (PhpServer, Child) {
 
     let port = FPM_DEFAULT_PORT.to_string();
 
+    // TODO systemd support should be detected dynamically on Linux
+    let systemd_support = !cfg!(target_os = "macos");
+
     let config = FPM_DEFAULT_CONFIG
         .replace("{{ uid }}", uid_str.as_str())
         .replace("{{ gid }}", gid_str.as_str())
         .replace("{{ port }}", port.as_str())
-        .replace("{{ log_level }}", FPM_DEFAULT_LOG_LEVEL);
+        .replace("{{ log_level }}", FPM_DEFAULT_LOG_LEVEL)
+        .replace("{{ systemd }}", if systemd_support { "" } else { ";" });
 
     let home = env::var("HOME").unwrap_or(String::from(""));
 


### PR DESCRIPTION
This PR does fix #16 and makes rymfony immediately usable on MacOS.

**Long story:**

My google skills failed me, I couldn't find any information on how to detect if FPM was compiled with systemd support via `--with-fpm-systemd ` but [this page at least tells me](https://www.nginx.com/resources/wiki/start/topics/examples/initscripts/) that I am likely right with completely deactivating it on Mac (which is using launchd).

For the Linux users:

Maybe we could try to query for systemd support on `target_os = "linux"` via the existence of an executable or some config file. Maybe as first step test if directory `/lib/systemd/` exists [as mentioned here](https://www.nginx.com/resources/wiki/start/topics/examples/systemd/).

But as the Linux part is just wild guessing I would like to keep it out of this PR as I have no test system available.


