### PR TITLE
auto detect free port from range

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -18,6 +18,7 @@ mod commands {
 mod utils {
     pub(crate) mod current_process_name;
     pub(crate) mod logger;
+    pub(crate) mod network;
     pub(crate) mod stop_process;
 }
 

--- a/src/utils/network.rs
+++ b/src/utils/network.rs
@@ -1,0 +1,12 @@
+use std::{net::TcpListener};
+
+pub(crate) fn find_port(default_port: u16) -> Option<u16> {
+    for port in default_port..65535 {
+        match TcpListener::bind(("127.0.0.1", port)) {
+            Ok(_p) => return Some(port),
+            _ => {}
+        }
+    }
+
+    None
+}


### PR DESCRIPTION
By now Ports were hardcoded and rymfony failed to start up multiple times.

This PR adds auto-detection of free ports.
You can now run multiple instances of rymfony (a feature that I use daily with the symfony binary).

Not sure about the multiple exit's via panic though. 
Looks like a program failure, while this should actually be a user-friendly error message.

Edit: Besides my own review comments there are two points I am unsure about:
- rymfony can now be started multiple times, BUT each time the same config file is used - in the long run that needs to be changed if we want to allow manual config changes. Possible solution: create the config filename from a hash of the absolute working directory name?
- The port detection iterates above all ports from the default port up to 65535 - for the HTTP listener that are >57k potential ports. Yes, they are not all blocked, but should we limit the amount of scanned ports?